### PR TITLE
fix dashboard service - remove zone id in the parameter

### DIFF
--- a/pomodify-backend/src/main/java/com/pomodify/backend/application/service/DashboardService.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/application/service/DashboardService.java
@@ -57,7 +57,7 @@ public class DashboardService {
             .map(s -> s.getCompletedAt().atZone(zone).toLocalDate())
             .collect(Collectors.toSet());
 
-        int currentStreak = user.getCurrentStreak(focusDays, today, zone);
+        int currentStreak = user.getCurrentStreak(focusDays, today);
         int bestStreak = user.getBestStreak(focusDays);
 
         List<DashboardResult.RecentSession> recentItems = recent.stream().map(s ->

--- a/pomodify-backend/src/test/java/com/pomodify/backend/domain/UserStreakTest.java
+++ b/pomodify-backend/src/test/java/com/pomodify/backend/domain/UserStreakTest.java
@@ -20,7 +20,7 @@ public class UserStreakTest {
         days.add(today.minusDays(2));
         days.add(today.minusDays(1));
         days.add(today);
-        int streak = user.getCurrentStreak(days, today, ZoneId.systemDefault());
+        int streak = user.getCurrentStreak(days, today);
         assertEquals(3, streak);
     }
 
@@ -32,7 +32,7 @@ public class UserStreakTest {
         days.add(today.minusDays(3));
         days.add(today.minusDays(1));
         days.add(today);
-        int streak = user.getCurrentStreak(days, today, ZoneId.systemDefault());
+        int streak = user.getCurrentStreak(days, today);
         assertEquals(2, streak); // today and yesterday only
     }
 


### PR DESCRIPTION
fix error in dashboard service:
remove zone id in the parameter
update user streak to call getCurrentStreak(days, today) (removed zoneId)
update DashboardService to call user.getCurrentStreak(focusDays, today)