### PR TITLE
Hotfix: Session Request Payload Validation

### DIFF
--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/dto/request/session/SessionRequest.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/dto/request/session/SessionRequest.java
@@ -5,9 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record SessionRequest(
-        @NotNull(message = "Activity ID is required")
-        Long activityId,
-
         @NotBlank(message = "Session type is required")
         String sessionType,
 


### PR DESCRIPTION
Service: Pomodify Backend API
Date: December 5, 2025
Maintainer: @danielvictorioso03
Branch: [bugfix/backend/session] → staging

1. Version Control Summary
<img width="596" height="218" alt="image" src="https://github.com/user-attachments/assets/efcb0cf5-75c9-450f-88f7-3c6f405ac4b4" />

Versioning Logic
Major: Unchanged. No breaking changes introduced.
Minor: Unchanged. No new functionality added.
Patch: Incremented. Internal DTO validation fix.

2. Changelog
🐛 Bug Fixes (Patch Level)
Issue: Session Creation Payload Validation Error
Commit: acfdbe9 - fix create session payload

Symptoms:
Frontend unable to create pomodoro sessions. API returns validation error:

{
  "error": "Validation failed",
  "message": "Activity ID is required"
}

Root Cause:
The SessionRequest DTO incorrectly required [activityId] in the request body, but the API endpoint design passes [activityId] as a path parameter:

POST /api/v1/activities/{activityId}/sessions

This caused a mismatch where the frontend sends:
{
  "sessionType": "FOCUS",
  "focusTimeInMinutes": 25,
  "breakTimeInMinutes": 5,
  "cycles": 4
}

But the backend expected:
{
  "activityId": 123,  // ❌ Redundant - already in URL path
  "sessionType": "FOCUS",
  "focusTimeInMinutes": 25,
  "breakTimeInMinutes": 5,
  "cycles": 4
}

Fix:
Removed redundant [activityId] field and its @NotNull validation from [SessionRequest.java]:

public record SessionRequest(
-   @NotNull(message = "Activity ID is required")
-   Long activityId,
-
    @NotBlank(message = "Session type is required")
    String sessionType,

    @NotNull(message = "Focus time is required")
    @Min(value = 1, message = "Focus time must be at least 1 minute")
    Integer focusTimeInMinutes,

    @NotNull(message = "Break time is required")
    @Min(value = 1, message = "Break time must be at least 1 minute")
    Integer breakTimeInMinutes,

    @Min(value = 1, message = "Cycles must be at least 1")
    Integer cycles
) {}

