### PR TITLE
Centralize API versioning

### DIFF
--- a/pomodify-backend/src/main/java/com/pomodify/backend/infrastructure/config/ApiPathPrefixConfig.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/infrastructure/config/ApiPathPrefixConfig.java
@@ -1,0 +1,24 @@
+package com.pomodify.backend.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+@Configuration
+public class ApiPathPrefixConfig implements WebMvcConfigurer {
+
+    @Value("${api.version:v1}")
+    private String apiVersion;
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setPatternParser(new PathPatternParser());
+
+        String apiBasePath = "/api/" + apiVersion;
+
+        configurer.addPathPrefix(apiBasePath, handlerType ->
+                handlerType.getPackageName().startsWith("com.pomodify.backend.presentation.controller"));
+    }
+}

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/ActivityController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/ActivityController.java
@@ -21,7 +21,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/activities")
+@RequestMapping("/activities")
 @Slf4j
 @RequiredArgsConstructor
 public class ActivityController {

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/AuthController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/AuthController.java
@@ -22,7 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/auth")
 @Slf4j
 public class AuthController {
 

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/CategoryController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/CategoryController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/categories")
+@RequestMapping("/categories")
 @Slf4j
 public class CategoryController {
 

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/DashboardController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/DashboardController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.ZoneId;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping
 @RequiredArgsConstructor
 public class DashboardController {
 

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/PushController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/PushController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/v1/push")
+@RequestMapping("/push")
 @RequiredArgsConstructor
 public class PushController {
 

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/ReportsController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/ReportsController.java
@@ -19,7 +19,7 @@ import java.time.DayOfWeek;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 
 @RestController
-@RequestMapping("/api/v1/reports")
+@RequestMapping("/reports")
 @RequiredArgsConstructor
 public class ReportsController {
 

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/SessionController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/SessionController.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/activities/{activityId}/sessions")
+@RequestMapping("/activities/{activityId}/sessions")
 public class SessionController {
 
         private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/SettingsController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/SettingsController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/settings")
+@RequestMapping("/settings")
 @RequiredArgsConstructor
 public class SettingsController {
 

--- a/pomodify-backend/src/main/resources/application.properties
+++ b/pomodify-backend/src/main/resources/application.properties
@@ -27,3 +27,6 @@ fcm.service-account=${FCM_SERVICE_ACCOUNT:}
 # Spring Boot Actuator Configuration
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
+
+# API Versioning
+api.version=v1


### PR DESCRIPTION
Summary

Introduced global API versioning via api.version property and ApiPathPrefixConfig, automatically prefixing all presentation controllers with /api/{version}.
Refactored controller mappings to remove hardcoded /api/v1 segments and rely on the global prefix (e.g., /activities, [/auth], [/settings]
Added api.version to profile-specific properties ([application-dev.properties], [application-local.properties], [application-prod.properties] for environment configuration.

New config: ApiPathPrefixConfig in com.pomodify.backend.infrastructure.config
Reads api.version (default v1) and constructs /api/{apiVersion}.
Applies the prefix only to controllers under com.pomodify.backend.presentation.controller.
Updated controllers:
AuthController, ActivityController, CategoryController, SessionController, ReportsController, DashboardController, PushController, SettingsController.
External URLs remain backward compatible (e.g., POST /api/v1/auth/register).
Security: ensured /api/v1/auth/register, /login, /refresh remain publicly accessible via SecurityConfig while other endpoints still require JWT.

Behavioral Changes

API version can now be changed centrally through api.version without touching controller mappings.
All environments (default, dev, local, prod) can override the API version consistently.

Notes

This PR does not change business logic; it only centralizes routing/versioning and wiring.
Consumers should continue using /api/v1/... paths; future version bumps will be handled via configuration.