### PR TITLE
feat: Server-side scheduled push notifications for mobile background support

### DIFF
--- a/pomodify-backend/src/main/java/com/pomodify/backend/PomodifyApiApplication.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/PomodifyApiApplication.java
@@ -3,9 +3,11 @@ package com.pomodify.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class PomodifyApiApplication {
 
 	public static void main(String[] args) {

--- a/pomodify-backend/src/main/java/com/pomodify/backend/application/service/ScheduledPushService.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/application/service/ScheduledPushService.java
@@ -1,0 +1,129 @@
+package com.pomodify.backend.application.service;
+
+import com.pomodify.backend.domain.model.ScheduledPushNotification;
+import com.pomodify.backend.domain.repository.ScheduledPushNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * Service for managing scheduled push notifications.
+ * Allows scheduling notifications to be sent at a future time,
+ * enabling true mobile push notifications even when browser is closed.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduledPushService {
+
+    private final ScheduledPushNotificationRepository repository;
+    private final PushNotificationService pushNotificationService;
+
+    /**
+     * Schedule a push notification for a specific time
+     */
+    @Transactional
+    public ScheduledPushNotification scheduleNotification(
+            Long userId,
+            Long sessionId,
+            Long activityId,
+            String title,
+            String body,
+            Instant scheduledAt,
+            String notificationType,
+            String currentPhase
+    ) {
+        // Cancel any existing pending notifications for this session
+        if (sessionId != null) {
+            repository.cancelBySessionId(sessionId);
+        }
+
+        ScheduledPushNotification notification = ScheduledPushNotification.builder()
+                .userId(userId)
+                .sessionId(sessionId)
+                .activityId(activityId)
+                .title(title)
+                .body(body)
+                .scheduledAt(scheduledAt)
+                .notificationType(notificationType)
+                .currentPhase(currentPhase)
+                .build();
+
+        ScheduledPushNotification saved = repository.save(notification);
+        log.info("Scheduled push notification for user {} at {}: {}", userId, scheduledAt, title);
+        return saved;
+    }
+
+    /**
+     * Cancel all pending notifications for a session (e.g., when user pauses or stops)
+     */
+    @Transactional
+    public void cancelSessionNotifications(Long sessionId) {
+        int cancelled = repository.cancelBySessionId(sessionId);
+        if (cancelled > 0) {
+            log.info("Cancelled {} pending notifications for session {}", cancelled, sessionId);
+        }
+    }
+
+    /**
+     * Cancel all pending notifications for a user
+     */
+    @Transactional
+    public void cancelUserNotifications(Long userId) {
+        int cancelled = repository.cancelByUserId(userId);
+        if (cancelled > 0) {
+            log.info("Cancelled {} pending notifications for user {}", cancelled, userId);
+        }
+    }
+
+    /**
+     * Process due notifications - runs every 5 seconds
+     */
+    @Scheduled(fixedRate = 5000)
+    @Transactional
+    public void processDueNotifications() {
+        List<ScheduledPushNotification> dueNotifications = repository.findDueNotifications(Instant.now());
+        
+        for (ScheduledPushNotification notification : dueNotifications) {
+            try {
+                pushNotificationService.sendNotificationToUser(
+                        notification.getUserId(),
+                        notification.getTitle(),
+                        notification.getBody()
+                );
+                notification.markAsSent();
+                repository.save(notification);
+                log.info("Sent scheduled notification {} to user {}", notification.getId(), notification.getUserId());
+            } catch (Exception e) {
+                log.error("Failed to send scheduled notification {}: {}", notification.getId(), e.getMessage());
+                // Don't mark as sent - will retry on next cycle
+            }
+        }
+    }
+
+    /**
+     * Cleanup old notifications - runs daily at 3 AM
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupOldNotifications() {
+        Instant oneWeekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+        int deleted = repository.deleteOldNotifications(oneWeekAgo);
+        if (deleted > 0) {
+            log.info("Cleaned up {} old scheduled notifications", deleted);
+        }
+    }
+
+    /**
+     * Get pending notifications for a session
+     */
+    public List<ScheduledPushNotification> getPendingForSession(Long sessionId) {
+        return repository.findBySessionIdAndSentFalseAndCancelledFalse(sessionId);
+    }
+}

--- a/pomodify-backend/src/main/java/com/pomodify/backend/domain/model/ScheduledPushNotification.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/domain/model/ScheduledPushNotification.java
@@ -1,0 +1,71 @@
+package com.pomodify.backend.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.Instant;
+
+/**
+ * Entity for storing scheduled push notifications.
+ * Used to send notifications when timer completes, even if browser is closed.
+ */
+@Entity
+@Table(name = "scheduled_push_notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduledPushNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "body", nullable = false)
+    private String body;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private Instant scheduledAt;
+
+    @Column(name = "sent", nullable = false)
+    @Builder.Default
+    private boolean sent = false;
+
+    @Column(name = "cancelled", nullable = false)
+    @Builder.Default
+    private boolean cancelled = false;
+
+    @Column(name = "notification_type")
+    private String notificationType; // "PHASE_COMPLETE", "SESSION_COMPLETE"
+
+    @Column(name = "current_phase")
+    private String currentPhase; // "FOCUS", "BREAK"
+
+    @Column(name = "created_at")
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+
+    public void markAsSent() {
+        this.sent = true;
+    }
+
+    public void cancel() {
+        this.cancelled = true;
+    }
+
+    public boolean shouldSend() {
+        return !sent && !cancelled && Instant.now().isAfter(scheduledAt);
+    }
+}

--- a/pomodify-backend/src/main/java/com/pomodify/backend/domain/repository/ScheduledPushNotificationRepository.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/domain/repository/ScheduledPushNotificationRepository.java
@@ -1,0 +1,52 @@
+package com.pomodify.backend.domain.repository;
+
+import com.pomodify.backend.domain.model.ScheduledPushNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface ScheduledPushNotificationRepository extends JpaRepository<ScheduledPushNotification, Long> {
+
+    /**
+     * Find all notifications that are due to be sent
+     */
+    @Query("SELECT n FROM ScheduledPushNotification n WHERE n.sent = false AND n.cancelled = false AND n.scheduledAt <= :now")
+    List<ScheduledPushNotification> findDueNotifications(@Param("now") Instant now);
+
+    /**
+     * Find pending notifications for a specific session
+     */
+    List<ScheduledPushNotification> findBySessionIdAndSentFalseAndCancelledFalse(Long sessionId);
+
+    /**
+     * Find pending notifications for a user
+     */
+    List<ScheduledPushNotification> findByUserIdAndSentFalseAndCancelledFalse(Long userId);
+
+    /**
+     * Cancel all pending notifications for a session
+     */
+    @Modifying
+    @Query("UPDATE ScheduledPushNotification n SET n.cancelled = true WHERE n.sessionId = :sessionId AND n.sent = false AND n.cancelled = false")
+    int cancelBySessionId(@Param("sessionId") Long sessionId);
+
+    /**
+     * Cancel all pending notifications for a user
+     */
+    @Modifying
+    @Query("UPDATE ScheduledPushNotification n SET n.cancelled = true WHERE n.userId = :userId AND n.sent = false AND n.cancelled = false")
+    int cancelByUserId(@Param("userId") Long userId);
+
+    /**
+     * Delete old sent/cancelled notifications (cleanup)
+     */
+    @Modifying
+    @Query("DELETE FROM ScheduledPushNotification n WHERE (n.sent = true OR n.cancelled = true) AND n.createdAt < :before")
+    int deleteOldNotifications(@Param("before") Instant before);
+}

--- a/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/PushController.java
+++ b/pomodify-backend/src/main/java/com/pomodify/backend/presentation/controller/PushController.java
@@ -1,5 +1,7 @@
 package com.pomodify.backend.presentation.controller;
 
+import com.pomodify.backend.application.service.ScheduledPushService;
+import com.pomodify.backend.domain.model.ScheduledPushNotification;
 import com.pomodify.backend.domain.model.UserPushToken;
 import com.pomodify.backend.domain.repository.UserPushTokenRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.Map;
 
 @RestController
@@ -19,6 +22,7 @@ import java.util.Map;
 public class PushController {
 
     private final UserPushTokenRepository tokenRepo;
+    private final ScheduledPushService scheduledPushService;
 
     @PostMapping("/register-token")
     @Operation(summary = "Register or update push token")
@@ -135,5 +139,70 @@ public class PushController {
             try { userId = Long.parseLong(s); } catch (Exception ignored) {}
         }
         return userId;
+    }
+
+    // ==================== SCHEDULED PUSH NOTIFICATIONS ====================
+
+    @PostMapping("/schedule")
+    @Operation(summary = "Schedule a push notification for timer completion")
+    public ResponseEntity<?> scheduleNotification(@AuthenticationPrincipal Jwt jwt,
+                                                   @RequestBody Map<String, Object> payload) {
+        if (jwt == null) return ResponseEntity.status(401).body("Unauthorized");
+        Long userId = extractUserId(jwt);
+        if (userId == null) return ResponseEntity.status(401).body("Invalid user claim");
+
+        try {
+            Long sessionId = payload.get("sessionId") != null ? 
+                ((Number) payload.get("sessionId")).longValue() : null;
+            Long activityId = payload.get("activityId") != null ? 
+                ((Number) payload.get("activityId")).longValue() : null;
+            String title = (String) payload.get("title");
+            String body = (String) payload.get("body");
+            Long delaySeconds = payload.get("delaySeconds") != null ? 
+                ((Number) payload.get("delaySeconds")).longValue() : null;
+            String notificationType = (String) payload.getOrDefault("notificationType", "PHASE_COMPLETE");
+            String currentPhase = (String) payload.get("currentPhase");
+
+            if (title == null || body == null || delaySeconds == null) {
+                return ResponseEntity.badRequest().body("Missing required fields: title, body, delaySeconds");
+            }
+
+            Instant scheduledAt = Instant.now().plusSeconds(delaySeconds);
+            
+            ScheduledPushNotification notification = scheduledPushService.scheduleNotification(
+                userId, sessionId, activityId, title, body, scheduledAt, notificationType, currentPhase
+            );
+
+            return ResponseEntity.ok(Map.of(
+                "id", notification.getId(),
+                "scheduledAt", notification.getScheduledAt().toString(),
+                "message", "Notification scheduled successfully"
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Failed to schedule notification: " + e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/schedule/{sessionId}")
+    @Operation(summary = "Cancel scheduled notifications for a session")
+    public ResponseEntity<?> cancelScheduledNotifications(@AuthenticationPrincipal Jwt jwt,
+                                                          @PathVariable Long sessionId) {
+        if (jwt == null) return ResponseEntity.status(401).body("Unauthorized");
+        Long userId = extractUserId(jwt);
+        if (userId == null) return ResponseEntity.status(401).body("Invalid user claim");
+
+        scheduledPushService.cancelSessionNotifications(sessionId);
+        return ResponseEntity.ok(Map.of("message", "Scheduled notifications cancelled"));
+    }
+
+    @DeleteMapping("/schedule")
+    @Operation(summary = "Cancel all scheduled notifications for current user")
+    public ResponseEntity<?> cancelAllScheduledNotifications(@AuthenticationPrincipal Jwt jwt) {
+        if (jwt == null) return ResponseEntity.status(401).body("Unauthorized");
+        Long userId = extractUserId(jwt);
+        if (userId == null) return ResponseEntity.status(401).body("Invalid user claim");
+
+        scheduledPushService.cancelUserNotifications(userId);
+        return ResponseEntity.ok(Map.of("message", "All scheduled notifications cancelled"));
     }
 }

--- a/pomodify-backend/src/main/resources/db/migration/V10__create_scheduled_push_notifications.sql
+++ b/pomodify-backend/src/main/resources/db/migration/V10__create_scheduled_push_notifications.sql
@@ -1,0 +1,28 @@
+-- Create scheduled_push_notifications table for server-side timer notifications
+CREATE TABLE IF NOT EXISTS scheduled_push_notifications (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    session_id BIGINT,
+    activity_id BIGINT,
+    title VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    scheduled_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    sent BOOLEAN NOT NULL DEFAULT FALSE,
+    cancelled BOOLEAN NOT NULL DEFAULT FALSE,
+    notification_type VARCHAR(50),
+    current_phase VARCHAR(20),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    
+    CONSTRAINT fk_scheduled_push_user FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
+);
+
+-- Index for efficient querying of due notifications
+CREATE INDEX idx_scheduled_push_due ON scheduled_push_notifications (scheduled_at, sent, cancelled) 
+    WHERE sent = FALSE AND cancelled = FALSE;
+
+-- Index for session-based lookups
+CREATE INDEX idx_scheduled_push_session ON scheduled_push_notifications (session_id) 
+    WHERE sent = FALSE AND cancelled = FALSE;
+
+-- Index for user-based lookups
+CREATE INDEX idx_scheduled_push_user ON scheduled_push_notifications (user_id);

--- a/pomodify-frontend/src/app/core/config/api.config.ts
+++ b/pomodify-frontend/src/app/core/config/api.config.ts
@@ -148,6 +148,9 @@ export const API = {
     STATUS: `${ROOT}/push/status`,
     ENABLE: `${ROOT}/push/enable`,
     DISABLE: `${ROOT}/push/disable`,
+    SCHEDULE: `${ROOT}/push/schedule`,
+    CANCEL_SCHEDULE: (sessionId: number) => `${ROOT}/push/schedule/${sessionId}`,
+    CANCEL_ALL_SCHEDULES: `${ROOT}/push/schedule`,
   },
 
   // Badges Resource

--- a/pomodify-frontend/src/app/core/services/scheduled-push.service.ts
+++ b/pomodify-frontend/src/app/core/services/scheduled-push.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, of } from 'rxjs';
+import { API } from '../config/api.config';
+
+export interface SchedulePushRequest {
+  sessionId: number;
+  activityId: number;
+  title: string;
+  body: string;
+  delaySeconds: number;
+  notificationType: 'PHASE_COMPLETE' | 'SESSION_COMPLETE';
+  currentPhase: 'FOCUS' | 'BREAK';
+}
+
+export interface SchedulePushResponse {
+  id: number;
+  scheduledAt: string;
+  message: string;
+}
+
+/**
+ * Service for scheduling server-side push notifications.
+ * This enables true mobile push notifications even when the browser is closed.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ScheduledPushService {
+  private http = inject(HttpClient);
+
+  /**
+   * Schedule a push notification to be sent when the timer completes.
+   * The server will send the notification at the scheduled time,
+   * even if the browser is closed.
+   */
+  scheduleNotification(request: SchedulePushRequest): Observable<SchedulePushResponse | null> {
+    console.log('📅 Scheduling server-side push notification:', {
+      sessionId: request.sessionId,
+      delaySeconds: request.delaySeconds,
+      phase: request.currentPhase
+    });
+
+    return this.http.post<SchedulePushResponse>(API.PUSH.SCHEDULE, request).pipe(
+      catchError(error => {
+        console.warn('⚠️ Failed to schedule push notification:', error);
+        // Don't fail silently - return null so caller knows it failed
+        return of(null);
+      })
+    );
+  }
+
+  /**
+   * Cancel scheduled notifications for a specific session.
+   * Call this when user pauses, stops, or manually completes a phase.
+   */
+  cancelSessionNotifications(sessionId: number): Observable<any> {
+    console.log('🚫 Cancelling scheduled notifications for session:', sessionId);
+
+    return this.http.delete(API.PUSH.CANCEL_SCHEDULE(sessionId)).pipe(
+      catchError(error => {
+        console.warn('⚠️ Failed to cancel scheduled notifications:', error);
+        return of(null);
+      })
+    );
+  }
+
+  /**
+   * Cancel all scheduled notifications for the current user.
+   */
+  cancelAllNotifications(): Observable<any> {
+    console.log('🚫 Cancelling all scheduled notifications');
+
+    return this.http.delete(API.PUSH.CANCEL_ALL_SCHEDULES).pipe(
+      catchError(error => {
+        console.warn('⚠️ Failed to cancel all scheduled notifications:', error);
+        return of(null);
+      })
+    );
+  }
+
+  /**
+   * Helper to calculate notification content based on phase
+   */
+  getNotificationContent(
+    currentPhase: 'FOCUS' | 'BREAK',
+    activityTitle: string
+  ): { title: string; body: string } {
+    if (currentPhase === 'FOCUS') {
+      return {
+        title: 'Focus Phase Complete! 🎯',
+        body: `Time for a break from "${activityTitle}". Step away and recharge!`
+      };
+    } else {
+      return {
+        title: 'Break Phase Complete! ⏰',
+        body: `Break time is over. Ready to focus on "${activityTitle}" again?`
+      };
+    }
+  }
+}

--- a/pomodify-frontend/src/app/pages/session-timer/session-timer.ts
+++ b/pomodify-frontend/src/app/pages/session-timer/session-timer.ts
@@ -26,6 +26,7 @@ import { Auth } from '../../core/services/auth';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NotificationService } from '../../core/services/notification.service';
 import { SettingsService } from '../../core/services/settings.service';
+import { ScheduledPushService } from '../../core/services/scheduled-push.service';
 import { environment } from '../../../environments/environment';
 
 /**
@@ -58,6 +59,7 @@ export class SessionTimerComponent implements OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private notificationService = inject(NotificationService);
   private settingsService = inject(SettingsService);
+  private scheduledPushService = inject(ScheduledPushService);
 
   // Auto-start functionality
   protected showAutoStartCountdown = signal(false);
@@ -372,6 +374,9 @@ export class SessionTimerComponent implements OnDestroy {
       };
       this.session.set(updatedSession);
       this.timerSyncService.startTimer();
+      
+      // Schedule server-side push notification for when timer completes
+      this.scheduleServerPushNotification(updatedSession);
       return;
     }
 
@@ -389,6 +394,9 @@ export class SessionTimerComponent implements OnDestroy {
         this.session.set(updated);
         this.timerSyncService.updateFromSession(updated);
         this.timerSyncService.startTimer();
+        
+        // Schedule server-side push notification for when timer completes
+        this.scheduleServerPushNotification(updated);
       },
       error: (err) => {
         // If start fails, still start the timer locally to prevent disruption
@@ -401,6 +409,9 @@ export class SessionTimerComponent implements OnDestroy {
           this.session.set(startedSession);
           this.timerSyncService.updateFromSession(startedSession);
           this.timerSyncService.startTimer();
+          
+          // Still try to schedule push notification
+          this.scheduleServerPushNotification(startedSession);
         } else {
           this.handleError(err, 'start session');
         }
@@ -415,6 +426,9 @@ export class SessionTimerComponent implements OnDestroy {
 
     // Pause timer sync service
     this.timerSyncService.pauseTimer();
+    
+    // Cancel any scheduled server-side push notifications
+    this.cancelScheduledPushNotification(sess.id);
 
     // Update local state immediately
     const pausedSession: PomodoroSession = {
@@ -449,6 +463,9 @@ export class SessionTimerComponent implements OnDestroy {
         this.session.set(updated);
         this.timerSyncService.updateFromSession(updated);
         this.timerSyncService.startTimer();
+        
+        // Schedule server-side push notification for when timer completes
+        this.scheduleServerPushNotification(updated);
       },
       error: (err) => {
         // If resume fails, update local state and start timer anyway
@@ -460,6 +477,9 @@ export class SessionTimerComponent implements OnDestroy {
         this.session.set(resumedSession);
         this.timerSyncService.updateFromSession(resumedSession);
         this.timerSyncService.startTimer();
+        
+        // Still try to schedule push notification
+        this.scheduleServerPushNotification(resumedSession);
       }
     });
   }
@@ -484,6 +504,9 @@ export class SessionTimerComponent implements OnDestroy {
       if (!confirmed) return;
 
       this.timerSyncService.stopTimer();
+      
+      // Cancel any scheduled server-side push notifications
+      this.cancelScheduledPushNotification(sess.id);
 
       this.sessionService.stopSession(actId, sess.id).subscribe({
         next: (updated) => {
@@ -518,6 +541,9 @@ export class SessionTimerComponent implements OnDestroy {
       if (!confirmed) return;
 
       this.timerSyncService.stopTimer();
+      
+      // Cancel any scheduled server-side push notifications
+      this.cancelScheduledPushNotification(sess.id);
 
       this.sessionService.finishSession(actId, sess.id, this.notes).subscribe({
         next: (updated) => {
@@ -547,6 +573,9 @@ export class SessionTimerComponent implements OnDestroy {
 
     // Store current phase before API call (it may change after)
     const currentPhase = sess.currentPhase || 'FOCUS';
+    
+    // Cancel any scheduled server-side push notifications (frontend handled the completion)
+    this.cancelScheduledPushNotification(sess.id);
 
     this.sessionService.completePhase(actId, sess.id).subscribe({
       next: (updated) => {
@@ -1089,7 +1118,17 @@ export class SessionTimerComponent implements OnDestroy {
     // If session is paused (after phase completion), just start the timer
     if (sess.status === 'PAUSED') {
       console.log('✅ Auto-start: Starting timer for next phase');
+      
+      // Update session status to IN_PROGRESS
+      const updatedSession: PomodoroSession = {
+        ...sess,
+        status: 'IN_PROGRESS'
+      };
+      this.session.set(updatedSession);
       this.timerSyncService.startTimer();
+      
+      // Schedule server-side push notification for when timer completes
+      this.scheduleServerPushNotification(updatedSession);
     } else {
       console.log('⚠️ Auto-start: Session not in expected PAUSED state, current status:', sess.status);
       // Try to start anyway
@@ -1143,6 +1182,78 @@ export class SessionTimerComponent implements OnDestroy {
     
     // Simulate phase completion
     this.checkAndHandleAutoStart(sess, sess.currentPhase || 'FOCUS');
+  }
+
+  /* -------------------- SERVER-SIDE PUSH NOTIFICATIONS -------------------- */
+
+  /**
+   * Schedule a server-side push notification for when the timer completes.
+   * This enables true mobile push notifications even when the browser is closed.
+   */
+  private scheduleServerPushNotification(session: PomodoroSession): void {
+    const settings = this.settingsService.getSettings();
+    
+    // Only schedule if notifications are enabled
+    if (!settings.notifications) {
+      console.log('📵 Notifications disabled - skipping server-side push scheduling');
+      return;
+    }
+
+    const remainingSeconds = this.remainingSeconds();
+    if (remainingSeconds <= 0) {
+      console.log('⏰ No remaining time - skipping server-side push scheduling');
+      return;
+    }
+
+    const actId = this.activityId();
+    if (!actId) {
+      console.log('❌ No activity ID - skipping server-side push scheduling');
+      return;
+    }
+
+    const currentPhase = (session.currentPhase || 'FOCUS') as 'FOCUS' | 'BREAK';
+    const activityTitle = this.activityTitle();
+    const { title, body } = this.scheduledPushService.getNotificationContent(currentPhase, activityTitle);
+
+    console.log(`📅 Scheduling server-side push notification in ${remainingSeconds} seconds for ${currentPhase} phase`);
+
+    this.scheduledPushService.scheduleNotification({
+      sessionId: session.id,
+      activityId: actId,
+      title,
+      body,
+      delaySeconds: remainingSeconds,
+      notificationType: 'PHASE_COMPLETE',
+      currentPhase
+    }).subscribe({
+      next: (response) => {
+        if (response) {
+          console.log('✅ Server-side push notification scheduled:', response.scheduledAt);
+        } else {
+          console.log('⚠️ Failed to schedule server-side push notification');
+        }
+      },
+      error: (err) => {
+        console.error('❌ Error scheduling server-side push notification:', err);
+      }
+    });
+  }
+
+  /**
+   * Cancel any scheduled server-side push notifications for a session.
+   * Called when user pauses, stops, or manually completes a phase.
+   */
+  private cancelScheduledPushNotification(sessionId: number): void {
+    console.log('🚫 Cancelling scheduled server-side push notification for session:', sessionId);
+    
+    this.scheduledPushService.cancelSessionNotifications(sessionId).subscribe({
+      next: () => {
+        console.log('✅ Scheduled push notification cancelled');
+      },
+      error: (err) => {
+        console.error('❌ Error cancelling scheduled push notification:', err);
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Implements server-side scheduled push notifications to enable true mobile push notifications even when the browser is closed or phone is locked.

## Problem
Previously, push notifications only worked when the app was open in the foreground. Mobile users wouldn't receive notifications when their phone was locked or browser was closed.

## Solution
Added a server-side scheduling system where:
1. Frontend schedules a notification when timer starts/resumes
2. Backend stores the scheduled time in database
3. Backend checks every 5 seconds for due notifications and sends via FCM
4. Frontend cancels scheduled notification on pause/stop/phase complete

## Changes

### Backend
- Added `ScheduledPushNotification` entity and repository
- Added `ScheduledPushService` with @Scheduled polling (5s interval)
- Added endpoints: `POST /push/schedule`, `DELETE /push/schedule/{sessionId}`, `DELETE /push/schedule`
- Added Flyway migration V10 for scheduled_push_notifications table
- Enabled scheduling in main application

### Frontend
- Added `scheduled-push.service.ts` for API calls
- Updated `session-timer.ts` to schedule/cancel notifications on timer state changes
- Added new endpoints to API config

## Testing
- Start a timer → notification scheduled in DB
- Pause/stop timer → notification cancelled
- Let timer complete with phone locked → should receive push notification
