### PR TITLE
fix(profile): remove mock badge fallback

### DIFF
--- a/pomodify-frontend/src/app/pages/profile/profile.ts
+++ b/pomodify-frontend/src/app/pages/profile/profile.ts
@@ -141,34 +141,14 @@ export class Profile implements OnInit {
     this.badgesLoading.set(true);
     this.badgeService.getUserBadges().subscribe({
       next: (badges) => {
-        // Use API badges if available, otherwise use mock data for testing
-        if (badges && badges.length > 0) {
-          this.badges.set(badges);
-        } else {
-          this.badges.set(this.getMockBadges());
-        }
+        this.badges.set(badges ?? []);
         this.badgesLoading.set(false);
       },
       error: () => {
-        // Fallback to mock badges for testing when API fails
-        this.badges.set(this.getMockBadges());
+        this.badges.set([]);
         this.badgesLoading.set(false);
       }
     });
-  }
-
-  /**
-   * Mock badges for testing UI (remove in production)
-   */
-  private getMockBadges(): Badge[] {
-    return [
-      { id: 1, name: 'The Bookmark', milestoneDays: 3, dateAwarded: '2025-12-20', imageUrl: 'assets/images/badges/the-bookmark.png' },
-      { id: 2, name: 'Deep Work', milestoneDays: 7, dateAwarded: '2025-12-24', imageUrl: 'assets/images/badges/deep-work.png' },
-      { id: 3, name: 'The Protégé', milestoneDays: 14, dateAwarded: '2025-12-29', imageUrl: 'assets/images/badges/the-protégé.png' },
-      { id: 4, name: 'The Curator', milestoneDays: 30, dateAwarded: '2025-12-29', imageUrl: 'assets/images/badges/the-curator.png' },
-      { id: 5, name: 'The Scholar', milestoneDays: 100, dateAwarded: '2025-12-29', imageUrl: 'assets/images/badges/the-scholar.png' },
-      { id: 6, name: 'The Alchemist', milestoneDays: 365, dateAwarded: '2025-12-29', imageUrl: 'assets/images/badges/the-alchemist.png' },
-    ];
   }
 
   // Profile image handling


### PR DESCRIPTION
What changed:
Removed the getMockBadges() method and fallback logic from the profile component. Badges now display only from the actual API response.

Why:
The badge feature is fully implemented in the backend. Users should only see badges they've actually earned (e.g., hitting a 3-day streak), not hardcoded test data.

Testing:
Profile shows empty Achievements section for new users
Badges appear once user earns them via streak milestones